### PR TITLE
Minor tweaks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 node_modules/
 .sass-cache/
+*.DS_Store
+.AppleDouble
+.LSOverride
+

--- a/README.md
+++ b/README.md
@@ -1,13 +1,21 @@
 # D8starter
-Drupal 8 starter theme, bootstrap 3, gulp, sass and font awesome included.
+D8starter, as its name implies, is a [Drupal 8](https://www.drupal.org/download "Download Drupal 8") starter theme with [Bootstrap 3](http://getbootstrap.com/ "Bootstrap • The world's most popular mobile-first and responsive front-end framework."), [Gulp](http://gulpjs.com/ "gulp.js"), [Sass](http://sass-lang.com/ "Sass: Syntactically Awesome Style Sheets") and [Font Awesome](http://fontawesome.io/ "Font Awesome, the iconic font and CSS toolkit"), all included.
 
-What do you need?
+## What do you need?
 
-1. Node.js
-2. Gulp
+1. [Node.js](https://nodejs.org/en/download/ "Download Node.js")
+2. [Gulp](http://gulpjs.com "gulp.js")
 
-How to use?
+## Usage
 
-1. Go to your dir and simply clone repo in console > git clone https://github.com/kwegiel/d8starter.git .
-2. Type > npm install
-3. You're ready to go > gulp watch
+1. Using your native terminal/console, go to your desired directory and clone this repository:
+> `git clone https://github.com/kwegiel/d8starter.git`
+
+2. Change to the newly downloaded directory:
+> `cd d8starter`
+
+3. Use the node package manager to finish the installation:
+> `npm install`
+
+3. You're (almost) ready to go. Get Gulp to “watch” your Sass files so that they are automatically compiled to CSS when saved:
+> `gulp watch`


### PR DESCRIPTION
Hello,  Krzysztof,

I've added a few extra details to the README.md, including links to relevant project pages so that anyone new to any of the technologies can more easily get up to speed. (The links should also help SEO for this project.) I've also played with the description text and added some clarification for the installation steps. In the .gitignore, I've also added entries for standard "Mac (hidden) files", so they won't show up as "untracked" (or accidentally end up in commits).

The Github project description isn't tracked by Git, but I would suggest capitalizing the project names (with minor re-wording): "Drupal 8 starter theme, with Bootstrap 3, Gulp, Sass and Font Awesome, all included."

Thank you for sharing this repo. :smile:

Lowell